### PR TITLE
Create LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,1 @@
+By installing this extension, you agree to the Datadog End-User License Agreement. You can view the agreement here: https://www.datadoghq.com/legal/eula/


### PR DESCRIPTION
Add `LICENSE.txt` file that contains:

> By installing this extension, you agree to the Datadog End-User License Agreement. You can view the agreement here: https://www.datadoghq.com/legal/eula/